### PR TITLE
update insights initialization to pipe separated instead of comma

### DIFF
--- a/people-controller.php
+++ b/people-controller.php
@@ -40,7 +40,7 @@ elseif($_POST['action'] == 'add'):
 					h($fromform['Super']),
 					h($fromform['Manager']),
 					h($fromform['Pronouns']),
-					'0,50,50,50,50',
+					'0|50|50|50|50',
 					0,
 					0
 		);


### PR DESCRIPTION
This value is used via an `explode()` on the pipe character, so some folks that were added recently had commas instead, which resulted in their graph being shown (with default values) despite the opt-in value being 0.