### PR TITLE
update pronouns to be unspecified if blank

### DIFF
--- a/people-controller.php
+++ b/people-controller.php
@@ -30,6 +30,7 @@ elseif($_POST['action'] == 'add'):
 
 	//IDIR,Role,Name,Email,Status,Phone,Title,Super,Manager,Pronouns,Colors,iStore,kepler
 	$fromform = $_POST;
+	$pronouns = $fromform['Pronouns'] ? $fromform['Pronouns'] : 'Unspecified';
 	$newadmin = Array(strtolower(h($fromform['idir'])),
 					h($fromform['role']),
 					h($fromform['name']),
@@ -39,7 +40,7 @@ elseif($_POST['action'] == 'add'):
 					h($fromform['title']),
 					h($fromform['Super']),
 					h($fromform['Manager']),
-					h($fromform['Pronouns']),
+					$pronouns,
 					'0|50|50|50|50',
 					0,
 					0

--- a/people.php
+++ b/people.php
@@ -78,7 +78,7 @@
 		<form method="post"	class="newuser col" action="people-controller.php">
 
 			<input type="hidden" name="action" value="add">
-			<select name="role" id="role" class="form-control mb-2" required>
+			<select name="role" id="role" class="form-select mb-2" required>
 				<option value="Operations">Operations</option>
 				<option value="Delivery">Delivery</option>
 				<option value="Developer">Development</option>
@@ -97,7 +97,7 @@
 			<input type="hidden" name="Super" id="Super" class="form-control  mb-2" placeholder="Super user? 0 for no, 1 for yes" required>
 			<input type="hidden" name="Manager" id="Manager" class="form-control  mb-2" placeholder="Manager? 0 for no, 1 for yes" required>
 			<?php endif ?>
-			<input type="text" name="Pronouns" id="Pronouns" class="form-control  mb-2" placeholder="Personal pronouns e.g. She/Hers/They" required>
+			<input type="text" name="Pronouns" id="Pronouns" class="form-control  mb-2" placeholder="Personal pronouns e.g. She/Hers/They">
 			<input type="submit" class="btn btn-primary" value="Add Person">
 
 		</form>

--- a/person-update.php
+++ b/person-update.php
@@ -31,6 +31,8 @@ if($_POST):
 		$headers = fgetcsv($f);
 		fputcsv($temp_table,$headers);
 		
+		$pronouns = $fromform['Pronouns'] ? $fromform['Pronouns'] : 'Unspecified';
+		
 		// IDIR,Role,Name,Email,Status,Phone,Title,Super,Director,Pronouns,Colors,iStore,kepler
 		$person = Array($idir,
 					h($fromform['Role']),
@@ -41,7 +43,7 @@ if($_POST):
 					h($fromform['Title']),
 					h($fromform['Super']),
 					h($fromform['Manager']),
-					h($fromform['Pronouns']),
+					$pronouns,
 					h($fromform['Colors']),
 					h($fromform['iStore']),
 					h($fromform['Kepler'])
@@ -175,7 +177,7 @@ else: ?>
 	<label for="Kepler">Kepler Access: </label>
 	<input type="text" name="Kepler" id="Kepler" class="form-control" value="<?php if(isset($p[12])) echo $p[12] ?>">
 </div>
-<button class="btn btn-block btn-primary my-3">Save Person</button>
+<button type="submit" class="btn btn-block btn-primary my-3">Save Person</button>
 
 </form>
 	


### PR DESCRIPTION
Some pages, such as `teams-all.php` are looking specifically for 'Unspecified' to determine whether to show pronouns.

Updated the people creation and update pages to set the value to 'Unspecified' if it's left blank, and made the field no longer required for person creation.