### PR TITLE
count active change requests and show badge and link

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -7,6 +7,24 @@
 
 <?php getNavigation() ?>
 
+<?php 
+// Get all change request JSON files
+$files = glob("course-change/requests/*.json");
+
+// Initialize a counter to count open requests
+$changeRequests = 0;
+
+foreach ($files as $file) {
+    $changeData = json_decode(file_get_contents($file), true);
+
+	// count not closed requests
+    if ($changeData) {
+        if ($changeData['progress'] !== 'Closed') {
+			$changeRequests++;
+		}
+    }
+}
+?>
 
 <?php if(isAdmin()): ?>
 <div class="container-fluid">
@@ -63,8 +81,10 @@
 </div>
 <div class="col-md-3">
 
-<h3>Pending Course Changes</h3>
-<p>Temporarily disabled.</p>
+<h3>Pending Course Changes <span class="badge text-bg-dark"><?= $changeRequests > 0 ? $changeRequests : '' ?></span></h3>
+<?php if ($changeRequests > 0): ?>
+	<a href="course-change/index.php">View change requests</a>
+<?php endif; ?>
 
 </div>
 <div class="col-md-6">


### PR DESCRIPTION
Added a count of the active change requests, and display a count badge and a link to the change request dashboard when there are active change requests.

As this is a temporary measure, I've just implemented as a function within the file, but will want to move to `lsapp.php` down the road so it can be re-used on other pages (DRY).