### PR TITLE
Fix partner ids

### DIFF
--- a/convert-partners-to-ids.php
+++ b/convert-partners-to-ids.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * One-off conversion script to update LearningHubPartner field in courses.csv
+ * from partner names to numeric IDs based on partners.json
+ * 
+ * Usage: php convert-partners-to-ids.php
+ */
+
+// Load partners.json to build name-to-id mapping
+$partnersJson = file_get_contents('data/partners.json');
+if (!$partnersJson) {
+    die("Error: Could not read partners.json\n");
+}
+
+$partners = json_decode($partnersJson, true);
+if (!$partners) {
+    die("Error: Could not parse partners.json\n");
+}
+
+// Build name-to-id mapping
+$partnerNameToId = [];
+foreach ($partners as $partner) {
+    $partnerNameToId[$partner['name']] = $partner['id'];
+}
+
+// Add manual mappings for known variations
+$partnerNameToId['Learning Centre'] = 59; // Maps to PSA Corporate Learning Branch
+$partnerNameToId['CIRMO'] = 78; // Maps to Corporate Information and Records Management Office
+// Map "Procurement Strategy and Governance Branch" to Unknown since it doesn't exist in partners.json
+$partnerNameToId['Procurement Strategy and Governance Branch'] = 372; // Maps to Unknown partner
+
+echo "Loaded " . count($partnerNameToId) . " partners from partners.json\n";
+echo "Partner name to ID mapping:\n";
+foreach ($partnerNameToId as $name => $id) {
+    echo "  - \"$name\" => $id\n";
+}
+echo "\n";
+
+// Process courses.csv
+$coursesFile = 'data/courses.csv';
+$tempFile = 'data/courses-temp-conversion.csv';
+
+if (!file_exists($coursesFile)) {
+    die("Error: courses.csv not found\n");
+}
+
+$input = fopen($coursesFile, 'r');
+if (!$input) {
+    die("Error: Could not open courses.csv for reading\n");
+}
+
+$output = fopen($tempFile, 'w');
+if (!$output) {
+    fclose($input);
+    die("Error: Could not create temporary file\n");
+}
+
+// Copy header row
+$headers = fgetcsv($input);
+if (!$headers) {
+    fclose($input);
+    fclose($output);
+    die("Error: Could not read headers from courses.csv\n");
+}
+fputcsv($output, $headers);
+
+// Track statistics
+$totalRows = 0;
+$convertedCount = 0;
+$notFoundCount = 0;
+$emptyCount = 0;
+$alreadyNumericCount = 0;
+$notFoundPartners = [];
+
+// Process each row
+while (($row = fgetcsv($input)) !== FALSE) {
+    $totalRows++;
+    
+    // LearningHubPartner is at index 36
+    if (isset($row[36])) {
+        $currentValue = trim($row[36]);
+        
+        if (empty($currentValue)) {
+            $emptyCount++;
+            echo "Row $totalRows: Empty partner field\n";
+        } elseif (is_numeric($currentValue)) {
+            $alreadyNumericCount++;
+            echo "Row $totalRows: Already numeric ID ($currentValue)\n";
+        } elseif (isset($partnerNameToId[$currentValue])) {
+            $oldValue = $currentValue;
+            $row[36] = $partnerNameToId[$currentValue];
+            $convertedCount++;
+            echo "Row $totalRows: Converted \"$oldValue\" to ID {$row[36]}\n";
+        } else {
+            $notFoundCount++;
+            if (!in_array($currentValue, $notFoundPartners)) {
+                $notFoundPartners[] = $currentValue;
+            }
+            echo "Row $totalRows: WARNING - Partner \"$currentValue\" not found in partners.json\n";
+        }
+    }
+    
+    fputcsv($output, $row);
+}
+
+fclose($input);
+fclose($output);
+
+// Display summary
+echo "\n=== CONVERSION SUMMARY ===\n";
+echo "Total rows processed: $totalRows\n";
+echo "Converted to IDs: $convertedCount\n";
+echo "Already numeric: $alreadyNumericCount\n";
+echo "Empty fields: $emptyCount\n";
+echo "Partners not found: $notFoundCount\n";
+
+if (count($notFoundPartners) > 0) {
+    echo "\nPartners not found in partners.json:\n";
+    foreach ($notFoundPartners as $partner) {
+        echo "  - \"$partner\"\n";
+    }
+}
+
+// Ask for confirmation before replacing the file
+echo "\nDo you want to replace courses.csv with the converted version? (yes/no): ";
+$handle = fopen("php://stdin", "r");
+$response = trim(fgets($handle));
+fclose($handle);
+
+if (strtolower($response) === 'yes' || strtolower($response) === 'y') {
+    // Create backup
+    $backupFile = 'data/courses-backup-' . date('Y-m-d-His') . '.csv';
+    if (copy($coursesFile, $backupFile)) {
+        echo "Created backup: $backupFile\n";
+    } else {
+        die("Error: Could not create backup file\n");
+    }
+    
+    // Replace original file
+    if (rename($tempFile, $coursesFile)) {
+        echo "Successfully updated courses.csv\n";
+    } else {
+        die("Error: Could not replace courses.csv\n");
+    }
+} else {
+    echo "Conversion cancelled. Temporary file saved as: $tempFile\n";
+    echo "You can manually review and rename it if needed.\n";
+}
+
+echo "\nConversion script complete.\n";

--- a/course-create.php
+++ b/course-create.php
@@ -179,7 +179,14 @@ if(!empty($_POST['CourseOwner']) || !empty($_POST['Developer'])) {
 // Check if this is from partner portal
 if (!empty($_POST['partner_redirect'])) {
     // Redirect back to partner portal dashboard
-    $partnerSlug = urlencode($_POST['LearningHubPartner']);
+    // Need to get partner slug from ID
+    $partnerInfo = getPartnerById($_POST['LearningHubPartner']);
+    if ($partnerInfo) {
+        $partnerSlug = urlencode($partnerInfo['slug']);
+    } else {
+        // Fallback to using the ID if partner not found
+        $partnerSlug = urlencode($_POST['LearningHubPartner']);
+    }
     header("Location: /learning/hub/partners/dashboard.php?partnerslug={$partnerSlug}&message=CourseCreated");
 } else {
     // Redirect to the new course page

--- a/course-feed/course-openaccess-publish.php
+++ b/course-feed/course-openaccess-publish.php
@@ -2,7 +2,7 @@
 opcache_reset();
 
 define('SLASH', DIRECTORY_SEPARATOR);
-$docroot = $_SERVER['DOCUMENT_ROOT'] . '/lsapp//';
+$docroot = 'E:\WebSites\Prod\BCPSA\Intranet\wwwroot\lsapp\\';
 define('BASE_DIR', $docroot);
 function build_path(...$segments) {
     return implode(SLASH, $segments);

--- a/course-request.php
+++ b/course-request.php
@@ -77,12 +77,18 @@ $reportinglist = getReportingList();
                 <select name="LearningHubPartner" id="LearningHubPartner" class="form-select" required>
                     <option value="" disabled selected>Select one</option>
                     <?php foreach($partners as $partner): ?>
-                        <option value="<?= sanitize($partner['name']) ?>"><?= sanitize($partner['name']) ?></option>
+                        <option value="<?= sanitize($partner['id']) ?>"><?= sanitize($partner['name']) ?></option>
                     <?php endforeach ?>
                 </select>
             </div>
             <div class="col-md-4 mb-3">
-                <label for="Platform" class="form-label">Platform</label>
+                <label for="Platform" class="form-label">
+                    Registration Platform
+                    <i class="bi bi-question-circle text-muted" 
+                       data-bs-toggle="tooltip" 
+                       data-bs-placement="top" 
+                       title="Set this to 'PSA Learning System' unless learners actually register through another platform."></i>
+                </label>
                 <select name="Platform" id="Platform" class="form-select" required>
                     <option value="" disabled selected>Select one</option>
                     <?php foreach($platforms as $platform): ?>
@@ -337,6 +343,12 @@ $reportinglist = getReportingList();
 <?php require('templates/javascript.php') ?>
 <script>
 $(document).ready(function(){
+    // Initialize Bootstrap tooltips
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+    
     // Platform-based field visibility
     $('#Platform').on('change', function() {
         if($(this).val() === 'PSA Learning System') {

--- a/course-update.php
+++ b/course-update.php
@@ -300,7 +300,7 @@ $reportinglist = getReportingList();
                 <select name="LearningHubPartner" id="LearningHubPartner" class="form-select" required>
                     <option value="" disabled <?= empty($deets[36]) ? 'selected' : '' ?>>Select one</option>
                     <?php foreach($partners as $partner): ?>
-                        <option value="<?= sanitize($partner['name']) ?>" <?= ($partner['name'] == $deets[36]) ? 'selected' : '' ?>>
+                        <option value="<?= sanitize($partner['id']) ?>" <?= ($partner['id'] == $deets[36]) ? 'selected' : '' ?>>
                             <?= sanitize($partner['name']) ?>
                         </option>
                     <?php endforeach ?>

--- a/course.php
+++ b/course.php
@@ -27,14 +27,18 @@ $partners = json_decode($partnersJson, true);
 $platformsJson = file_get_contents('data/platforms.json');
 $platformsData = json_decode($platformsJson, true);
 
-// Find the partner slug for this course
+// Find the partner information for this course
+$partnerInfo = null;
 $partnerSlug = '';
+$partnerName = '';
 if (!empty($deets[36])) {
-    foreach ($partners as $partner) {
-        if ($partner['name'] === $deets[36]) {
-            $partnerSlug = $partner['slug'];
-            break;
-        }
+    $partnerInfo = getPartnerById($deets[36]);
+    if ($partnerInfo) {
+        $partnerSlug = $partnerInfo['slug'];
+        $partnerName = $partnerInfo['name'];
+    } else {
+        // Fallback if partner not found - just show the ID
+        $partnerName = $deets[36];
     }
 }
 
@@ -304,9 +308,11 @@ if (file_exists($categoriesFile)) {
 <div class="col-md-4">
 <div class=""><strong>Corp. Partner:</strong><br> 
 <?php if (!empty($partnerSlug)): ?>
-    <a href="/lsapp/partners/view.php?slug=<?= $partnerSlug ?>"><?= $deets[36] ?></a>
+    <a href="/lsapp/partners/view.php?slug=<?= $partnerSlug ?>"><?= sanitize($partnerName) ?></a>
+<?php elseif (!empty($partnerName)): ?>
+    <?= sanitize($partnerName) ?>
 <?php else: ?>
-    <?= $deets[36] ?>
+    <span class="text-muted">Not set</span>
 <?php endif ?>
 </div>
 </div>

--- a/courses.php
+++ b/courses.php
@@ -400,9 +400,12 @@ function getFilterLink($filters, $key, $value = null) {
                         Corp. Partner: 
                         <?php if (!empty($course[36])): ?>
                             <?php 
-                            $partnerSlug = strtolower(preg_replace('/[^a-z0-9\s-]/i', '', str_replace(' ', '-', $course[36])));
-                            ?>
-                            <a href="partners/view.php?slug=<?= $partnerSlug ?>"><?= sanitize($course[36]) ?></a>
+                            $partnerInfo = getPartnerById($course[36]);
+                            if ($partnerInfo): ?>
+                                <a href="partners/view.php?slug=<?= $partnerInfo['slug'] ?>"><?= sanitize($partnerInfo['name']) ?></a>
+                            <?php else: ?>
+                                <?= sanitize($course[36]) ?>
+                            <?php endif; ?>
                         <?php else: ?>
                             N/A
                         <?php endif; ?>

--- a/learning/hub/partners/course-form.php
+++ b/learning/hub/partners/course-form.php
@@ -249,8 +249,10 @@ a:hover {
 <?php if ($courseid || isset($_GET['newcourse'])): ?>
 <?php
 if (isset($_GET['newcourse'])) {
+  // Use the partner ID instead of the slug/name
+  $partnerId = $matched_partner ? $matched_partner['id'] : '';
   $courseData = [
-    'LearningHubPartner' => $partnerslug,
+    'LearningHubPartner' => $partnerId,
     'CourseOwner' => LOGGED_IN_IDIR,
     'CourseID' => '',
     'CourseName' => '',
@@ -280,7 +282,15 @@ $formAction = isset($_GET['newcourse']) ? '../../../lsapp/course-create.php' : '
 <?php endif ?>
 
 <input type="hidden" name="user_idir" value="<?= LOGGED_IN_IDIR ?>">
-<input type="hidden" name="LearningHubPartner" value="<?= $courseData['LearningHubPartner'] ?>">
+<?php 
+// Ensure we're sending the partner ID, not the name
+$partnerValue = $courseData['LearningHubPartner'];
+// If it's not numeric, it might be a partner name - convert to ID
+if (!is_numeric($partnerValue) && $matched_partner) {
+    $partnerValue = $matched_partner['id'];
+}
+?>
+<input type="hidden" name="LearningHubPartner" value="<?= $partnerValue ?>">
 <input type="hidden" name="RequestedBy" value="<?= LOGGED_IN_IDIR ?>">
 <input type="hidden" name="Requested" value="<?= date('Y-m-d') ?>">
 <input type="hidden" name="EffectiveDate" value="<?= date('Y-m-d') ?>">

--- a/partners/dashboard.php
+++ b/partners/dashboard.php
@@ -127,7 +127,15 @@ endif;
         <?php foreach($filteredCourses as $course): ?>
         <tr>
             <td><a href="../course.php?courseid=<?php echo urlencode($course[0]); ?>"><?php echo htmlspecialchars($course[2]); ?></a></td>
-            <td><a href="view.php?slug=<?php echo urlencode($partnerMap[$course[36]]); ?>"><?php echo htmlspecialchars($course[36]); ?></a></td>
+            <td>
+                <?php 
+                $partnerInfo = getPartnerById($course[36]);
+                if ($partnerInfo): ?>
+                    <a href="view.php?slug=<?php echo urlencode($partnerInfo['slug']); ?>"><?php echo htmlspecialchars($partnerInfo['name']); ?></a>
+                <?php else: ?>
+                    <?php echo htmlspecialchars($course[36]); ?>
+                <?php endif; ?>
+            </td>
             <td><?php echo htmlspecialchars($course[1]); ?></td>
             <td><?php echo htmlspecialchars($course[14]); ?></td>
             <td><?php echo htmlspecialchars($course[15]); ?></td>


### PR DESCRIPTION
Prepare for a better migrate-to-database story by converting the LearningPartner field from storing the string of the partner name, to referencing the numeric ID of the partner. After we do this, the tables will be more normalized when we finally get this all into SQLite.