### PR TITLE
Email Notifications for Partner Management

### DIFF
--- a/learning/hub/partners/contact-request.php
+++ b/learning/hub/partners/contact-request.php
@@ -39,5 +39,52 @@ if (file_exists($file)) {
 $requests[] = $request;
 file_put_contents($file, json_encode($requests, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 
+// Send email notification
+require_once('../../../lsapp/inc/ches_client.php');
+
+try {
+    $ches = new CHESClient();
+
+    // Build email content
+    $subject = "Partner Access Request: " . $request['partner_name'];
+
+    $bodyHtml = "<h2>New Partner Access Request</h2>";
+    $bodyHtml .= "<p>A user has requested access to manage courses for a partner:</p>";
+    $bodyHtml .= "<table border='1' cellpadding='8' cellspacing='0' style='border-collapse: collapse; font-family: Arial, sans-serif;'>";
+    $bodyHtml .= "<tr><td><strong>Partner Name:</strong></td><td>" . htmlspecialchars($request['partner_name']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>Requester Name:</strong></td><td>" . htmlspecialchars($request['name']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>Email:</strong></td><td>" . htmlspecialchars($request['email']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>IDIR:</strong></td><td>" . htmlspecialchars($request['idir']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>Title:</strong></td><td>" . htmlspecialchars($request['title']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>Role:</strong></td><td>" . htmlspecialchars($request['role']) . "</td></tr>";
+    $bodyHtml .= "<tr><td><strong>Date Requested:</strong></td><td>" . htmlspecialchars($request['timestamp']) . "</td></tr>";
+    $bodyHtml .= "</table>";
+    $bodyHtml .= "<p><a href='https://gww.bcpublicservice.gov.bc.ca/lsapp/partners/dashboard.php'>View Partner Dashboard</a></p>";
+
+    $bodyText = "New Partner Access Request\n\n";
+    $bodyText .= "Partner Name: " . $request['partner_name'] . "\n";
+    $bodyText .= "Requester Name: " . $request['name'] . "\n";
+    $bodyText .= "Email: " . $request['email'] . "\n";
+    $bodyText .= "IDIR: " . $request['idir'] . "\n";
+    $bodyText .= "Title: " . $request['title'] . "\n";
+    $bodyText .= "Role: " . $request['role'] . "\n";
+    $bodyText .= "Date Requested: " . $request['timestamp'] . "\n\n";
+    $bodyText .= "View Partner Dashboard: https://gww.bcpublicservice.gov.bc.ca/lsapp/partners/dashboard.php\n";
+
+    // Send email
+    $result = $ches->sendEmail(
+        ['allan.haggett@gov.bc.ca'],
+        $subject,
+        $bodyText,
+        $bodyHtml,
+        'learninghub_noreply@gov.bc.ca'
+    );
+
+    error_log("Sent partner access request notification email (Transaction ID: {$result['txId']})");
+
+} catch (Exception $e) {
+    error_log("ERROR: Failed to send partner access request notification email: " . $e->getMessage());
+}
+
 header("Location: {$_SERVER['HTTP_REFERER']}");
 exit;

--- a/partners/contact-approve.php
+++ b/partners/contact-approve.php
@@ -36,6 +36,9 @@ $contact = [
 $partnerFile = '../data/partners.json';
 $partners = file_exists($partnerFile) ? json_decode(file_get_contents($partnerFile), true) : [];
 
+$partnerName = '';
+$partnerId = '';
+
 foreach ($partners as &$partner) {
     if ($partner['slug'] === $slug) {
         if (!isset($partner['contacts']) || !is_array($partner['contacts'])) {
@@ -46,6 +49,8 @@ foreach ($partners as &$partner) {
             $partner['employee_facing_contact'] = '';
         }
         $partner['contacts'][] = $contact;
+        $partnerName = $partner['name'];
+        $partnerId = $partner['id'];
         break;
     }
 }
@@ -61,6 +66,98 @@ $requests = array_filter($requests, function($r) use ($slug, $contact) {
     );
 });
 file_put_contents($requestsFile, json_encode(array_values($requests), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+// Send email notifications
+require_once('../inc/ches_client.php');
+
+try {
+    $ches = new CHESClient();
+
+    // 1. Send notification to admin (allan.haggett@gov.bc.ca)
+    $adminSubject = "Partner Admin Approved: " . htmlspecialchars($contact['name']) . " for " . htmlspecialchars($partnerName);
+
+    $adminBodyHtml = "<h2>Partner Admin Approved</h2>";
+    $adminBodyHtml .= "<p>A new partner administrator has been approved:</p>";
+    $adminBodyHtml .= "<table border='1' cellpadding='8' cellspacing='0' style='border-collapse: collapse; font-family: Arial, sans-serif;'>";
+    $adminBodyHtml .= "<tr><td><strong>Partner Name:</strong></td><td>" . htmlspecialchars($partnerName) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Contact Name:</strong></td><td>" . htmlspecialchars($contact['name']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Email:</strong></td><td>" . htmlspecialchars($contact['email']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>IDIR:</strong></td><td>" . htmlspecialchars($contact['idir']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Title:</strong></td><td>" . htmlspecialchars($contact['title']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Role:</strong></td><td>" . htmlspecialchars($contact['role']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Approved By:</strong></td><td>" . htmlspecialchars($contact['approved_by']) . "</td></tr>";
+    $adminBodyHtml .= "<tr><td><strong>Date Approved:</strong></td><td>" . htmlspecialchars($contact['added_at']) . "</td></tr>";
+    $adminBodyHtml .= "</table>";
+    $adminBodyHtml .= "<p><a href='https://gww.bcpublicservice.gov.bc.ca/lsapp/partners/dashboard.php'>View Partner Dashboard</a></p>";
+
+    $adminBodyText = "Partner Admin Approved\n\n";
+    $adminBodyText .= "Partner Name: " . $partnerName . "\n";
+    $adminBodyText .= "Contact Name: " . $contact['name'] . "\n";
+    $adminBodyText .= "Email: " . $contact['email'] . "\n";
+    $adminBodyText .= "IDIR: " . $contact['idir'] . "\n";
+    $adminBodyText .= "Title: " . $contact['title'] . "\n";
+    $adminBodyText .= "Role: " . $contact['role'] . "\n";
+    $adminBodyText .= "Approved By: " . $contact['approved_by'] . "\n";
+    $adminBodyText .= "Date Approved: " . $contact['added_at'] . "\n\n";
+    $adminBodyText .= "View Partner Dashboard: https://gww.bcpublicservice.gov.bc.ca/lsapp/partners/dashboard.php\n";
+
+    $adminResult = $ches->sendEmail(
+        ['allan.haggett@gov.bc.ca'],
+        $adminSubject,
+        $adminBodyText,
+        $adminBodyHtml,
+        'learninghub_noreply@gov.bc.ca'
+    );
+
+    error_log("Sent partner admin approval notification to admin (Transaction ID: {$adminResult['txId']})");
+
+    // 2. Send welcome email to the approved contact
+    $welcomeSubject = "Welcome - You've been approved as a Partner Administrator for " . htmlspecialchars($partnerName);
+
+    $partnerDashboardUrl = "https://gww.bcpublicservice.gov.bc.ca/learning/hub/partners/dashboard.php?partnerid=" . urlencode($partnerId);
+
+    $welcomeBodyHtml = "<h2>Welcome to the Learning Partner Program!</h2>";
+    $welcomeBodyHtml .= "<p>Hello " . htmlspecialchars($contact['name']) . ",</p>";
+    $welcomeBodyHtml .= "<p>Great news! You've been approved as a partner administrator for <strong>" . htmlspecialchars($partnerName) . "</strong>.</p>";
+    $welcomeBodyHtml .= "<h3>What's next?</h3>";
+    $welcomeBodyHtml .= "<p>You can now access the partner admin panel to manage courses for your organization:</p>";
+    $welcomeBodyHtml .= "<p><a href='" . htmlspecialchars($partnerDashboardUrl) . "' style='display: inline-block; padding: 10px 20px; background-color: #036; color: white; text-decoration: none; border-radius: 5px;'>Access Partner Admin Panel</a></p>";
+    $welcomeBodyHtml .= "<p>Or copy this link: <a href='" . htmlspecialchars($partnerDashboardUrl) . "'>" . htmlspecialchars($partnerDashboardUrl) . "</a></p>";
+    $welcomeBodyHtml .= "<h3>Your Details:</h3>";
+    $welcomeBodyHtml .= "<table border='1' cellpadding='8' cellspacing='0' style='border-collapse: collapse; font-family: Arial, sans-serif;'>";
+    $welcomeBodyHtml .= "<tr><td><strong>Partner:</strong></td><td>" . htmlspecialchars($partnerName) . "</td></tr>";
+    $welcomeBodyHtml .= "<tr><td><strong>Your Role:</strong></td><td>" . htmlspecialchars($contact['role']) . "</td></tr>";
+    $welcomeBodyHtml .= "<tr><td><strong>Date Approved:</strong></td><td>" . htmlspecialchars($contact['added_at']) . "</td></tr>";
+    $welcomeBodyHtml .= "</table>";
+    $welcomeBodyHtml .= "<p>If you have any questions, please don't hesitate to reach out.</p>";
+    $welcomeBodyHtml .= "<p>Thank you,<br>LearningHUB Team</p>";
+
+    $welcomeBodyText = "Welcome to the Learning Partner Program!\n\n";
+    $welcomeBodyText .= "Hello " . $contact['name'] . ",\n\n";
+    $welcomeBodyText .= "Great news! You've been approved as a partner administrator for " . $partnerName . ".\n\n";
+    $welcomeBodyText .= "What's next?\n";
+    $welcomeBodyText .= "You can now access the partner admin panel to manage courses for your organization:\n\n";
+    $welcomeBodyText .= $partnerDashboardUrl . "\n\n";
+    $welcomeBodyText .= "Your Details:\n";
+    $welcomeBodyText .= "Partner: " . $partnerName . "\n";
+    $welcomeBodyText .= "Your Role: " . $contact['role'] . "\n";
+    $welcomeBodyText .= "Date Approved: " . $contact['added_at'] . "\n\n";
+    $welcomeBodyText .= "If you have any questions, please don't hesitate to reach out.\n\n";
+    $welcomeBodyText .= "Thank you,\nLearningHUB Team\n";
+
+    $welcomeResult = $ches->sendEmail(
+        [$contact['email']],
+        $welcomeSubject,
+        $welcomeBodyText,
+        $welcomeBodyHtml,
+        'learninghub_noreply@gov.bc.ca'
+    );
+
+    error_log("Sent welcome email to approved contact {$contact['email']} (Transaction ID: {$welcomeResult['txId']})");
+
+} catch (Exception $e) {
+    error_log("ERROR: Failed to send approval notification emails: " . $e->getMessage());
+}
 
 header('Location: dashboard.php');
 exit;


### PR DESCRIPTION
Closes #129 
 
Added comprehensive email notifications using CHES (Common Hosted Email Service) for all partner-related form submissions and approvals.

  Changes

  1. New Partner Request Notifications (learning/hub/partners/process.php)

  When a new learning partner submits a request via the partner form:
  - Admin notification sent to allan.haggett@gov.bc.ca with full request details and link to partner dashboard
  - Confirmation emails sent to each administrative contact listed in the request, acknowledging receipt and setting expectations for review

  2. Partner Access Request Notifications (learning/hub/partners/contact-request.php)

  When a user requests access to manage courses for an existing partner:
  - Admin notification sent to allan.haggett@gov.bc.ca with requester details (name, email, IDIR, title, role) and partner information

  3. Partner Admin Approval Notifications (partners/contact-approve.php)

  When an admin approves a partner access request:
  - Admin notification sent to allan.haggett@gov.bc.ca showing who was approved and which IDIR approved them
  - Welcome email sent to the newly approved contact with:
    - Personalized greeting
    - Direct link to their partner admin panel with partner ID
    - Summary of their role and approval details

  Technical Details

  - All emails use the existing inc/ches_client.php CHES API client
  - Both HTML and plain text versions included for compatibility
  - Sender: learninghub_noreply@gov.bc.ca
  - Error handling prevents email failures from blocking form submissions
  - All email sends logged with transaction IDs for tracking
  - Follows the same pattern as existing ELM course sync notifications