### PR TITLE
remove overwriting procurement branch

### DIFF
--- a/inc/lsapp.php
+++ b/inc/lsapp.php
@@ -837,9 +837,6 @@ function getPartnerIdByName($partnerName) {
 	if($partnerName === 'CIRMO') {
 		return 78; // Maps to Corporate Information and Records Management Office
 	}
-	if($partnerName === 'Procurement Strategy and Governance Branch') {
-		return 372; // Maps to Unknown partner
-	}
 	
 	$partners = getAllPartners();
 	foreach($partners as $partner) {


### PR DESCRIPTION
Remove the block in `getPartnerIdByName()` that overrides and re-assigns the partner ID for Procurement Strategy and Governance Branch