### PR TITLE
add course-feed/data to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,7 @@
 /rosters
 /data
 /course-change/requests
-/course-feed/data/courses.csv
-/course-feed/data/bcps-corporate-learning-courses.json
-/course-feed/data/GBC_LEARNINGHUB_SYNC2.csv
+/course-feed/data
 # OS generated files #
 ######################
 .DS_Store


### PR DESCRIPTION
Add course-feed/data to git ignore list.

Will still need to confirm the process for removing the existing files from the repo, assuming they won't be removed automatically.

Also added an issue for the long term solution of relocating the course feed data over to the data directory.