### PR TITLE
Sync fixes and QOL improvements

### DIFF
--- a/survey/evaluation-sync.php
+++ b/survey/evaluation-sync.php
@@ -67,6 +67,7 @@ function syncForm($config) {
 
                 // add questions map to config
                 $return_config['questions'] = $questions_map;
+
             }
         }
     }
@@ -211,12 +212,6 @@ function getResponses($config) {
 
 }
 
-// $response = file_get_contents($endpoint_form_details, false, $context);
-// $formData = json_decode($response, true);
-
-// // testing form
-// $form_contents = file_get_contents('data/surveys/test-form.json');
-// $formData = json_decode($form_contents, true);
 
 
 // open and decode config file
@@ -282,12 +277,35 @@ if (!empty($form_id)) {
 
 }
 
-// otherwise sync the all forms in the config file
+// otherwise sync the set number of forms in the config file
 else {
+
+    $sync_max = 10;
+    $sync_count = 0;
+    $sync_logs = [];
+
+    usort($config, function($a, $b) {
+
+        $a_has_timestamp = isset($a['lastFormSync']);
+        $b_has_timestamp = isset($b['lastFormSync']);
+
+        // never synced first
+        if ($a_has_timestamp !== $b_has_timestamp) {
+            return $a_has_timestamp <=> $b_has_timestamp;
+        }
+        // both never synced, maintain order
+        if (!$a_has_timestamp && !$b_has_timestamp) {
+            return 0;
+        }
+        // order by last sync
+        return $a['lastFormSync'] <=> $b['lastFormSync'];
+
+    });
+
     foreach ($config as $form_config) {
         
-        // only sync active forms
-        if (isset($form_config['status']) && $form_config['status'] == 'active') {
+        // only sync active forms and while less than max syncs
+        if (isset($form_config['status']) && $form_config['status'] == 'active' && $sync_count < $sync_max ) {
 
             // sync the form and return an updated config
             $synced_form_config = syncForm($form_config);
@@ -298,8 +316,11 @@ else {
             // take the fully updated config and add to our array
             $updated_config[] = $synced_response_config;
 
+            $sync_logs[] = date('c') . ' - ' . $synced_form_config['name'] . ' has been updated';
+            $sync_count++;            
+
         }
-        # if form isn't active, add to new config as-is
+        // if form isn't active, add to new config as-is
         else {
             $updated_config[] = $form_config;
         }
@@ -313,17 +334,18 @@ $json_config = json_encode($updated_config, JSON_PRETTY_PRINT);
 file_put_contents($config_file, $json_config);
 
 
-// $test_questions = processVersionQuestions($test_result);
+$logs_file = $data_path . 'logs.txt';
+$max_logs = 100;
+$logs = file_exists($logs_file) ? file($logs_file, FILE_IGNORE_NEW_LINES) : [];
 
+$logs = array_merge($logs, $sync_logs);
 
+// if we're over max logs
+if (count($logs) > $max_logs) {
+    $logs = array_slice($logs, -$max_logs);
+}
 
-echo '<pre>';
-// print_r($test_result);
-echo '</pre>';
+file_put_contents($logs_file, implode(PHP_EOL, $logs) . PHP_EOL, LOCK_EX);
 
-echo '<pre>';
-// print_r($test_questions);
-echo '</pre>';
-
-
-
+AlertManager::addAlert('success', 'Survey synchronization complete');
+header('Location: ./sync.php');

--- a/survey/evaluation-sync.php
+++ b/survey/evaluation-sync.php
@@ -60,6 +60,7 @@ function syncForm($config) {
                 // reach out to version endpoint get the form version json
                 $version_data = getVersion($return_config);
                 $return_config['lastVersionUpdatedAt'] = $version_data['updatedAt'];
+                $return_config['lastVersionSync'] = time();
 
                 // process the version and extract questions to create our questions map
                 $questions_map = processVersionQuestions($version_data);
@@ -69,6 +70,8 @@ function syncForm($config) {
             }
         }
     }
+
+    $return_config['lastFormSync'] = time();
 
     return $return_config;
 

--- a/survey/evaluation-sync.php
+++ b/survey/evaluation-sync.php
@@ -35,7 +35,7 @@ function syncForm($config) {
     $form_data = json_decode($response, true);
 
     // update from form
-    $return_config['lastUpdated'] = $form_data['updatedAt'];
+    $return_config['lastFormUpdatedAt'] = $form_data['updatedAt'];
 
     $return_config['name'] = $form_data['name'];
     
@@ -59,6 +59,7 @@ function syncForm($config) {
                 
                 // reach out to version endpoint get the form version json
                 $version_data = getVersion($return_config);
+                $return_config['lastVersionUpdatedAt'] = $version_data['updatedAt'];
 
                 // process the version and extract questions to create our questions map
                 $questions_map = processVersionQuestions($version_data);

--- a/survey/index.php
+++ b/survey/index.php
@@ -79,17 +79,17 @@ foreach ($courses as $course) {
             
             <div class="container">
             <div class="row align-items-center">
-                <div class="col-8">
+                <div class="col-7">
                     <h5 class="card-title"><?= $survey['name'] ?? '' ?></h5>
                     <h6 class="card-subtitle text-body-secondary">
                         <?= !empty($survey['courseId']) ? $course_map[$survey['courseId']]['name'] . ' (' . $course_map[$survey['courseId']]['code'] . ')' : '' ?>
                     </h6>
                     <p class="card-text"><small class="text-body-secondary">Form ID: <?= $survey['formId'] ?></small></p>
                 </div>
-                <div class="col-2">
-                    <div><small>Last Sync: <?= isset($survey['lastResponsesUpdated']) ? date('Y-m-d', $survey['lastResponsesUpdated']) : 'n/a'  ?></small></div>
-                    <div><small>Recent Responses: #</small></div>
-                    <div><small>Another thing: #</small></div>
+                <div class="col-3">
+                    <div><small>Last Form Sync: <?= isset($survey['lastFormSync']) ? date('Y-m-d', $survey['lastFormSync']) : 'n/a' ?></small></div>
+                    <div><small>Last Version Sync: <?= isset($survey['lastVersionSync']) ? date('Y-m-d', $survey['lastVersionSync']) : 'n/a' ?></small></div>
+                    <div><small>Last Responses Sync: <?= isset($survey['lastResponsesUpdated']) ? date('Y-m-d', $survey['lastResponsesUpdated']) : 'n/a' ?></small></div>
                 </div>
                 <div class="col-2">
                     <div class="btn-group-vertical btn-group-sm float-end border" role="group" aria-label="Vertical button group">

--- a/survey/index.php
+++ b/survey/index.php
@@ -6,6 +6,20 @@ require('functions.php');
 
 // Get our survey config
 $config = getConfig();
+usort($config, function($a, $b) {
+    $a_has_name = isset($a['name']);
+    $b_has_name = isset($b['name']);
+
+    // without name first
+    if ($a_has_name !== $b_has_name) {
+        return $a_has_name <=> $b_has_name;
+    }
+    if (!$a_has_name && !$b_has_name) {
+        return 0;
+    }
+    // sort by name
+    return $a['name'] <=> $b['name'];
+});
 
 // get a list of response files
 $response_files = glob("../data/surveys/*-*-*-*.json");

--- a/survey/sync.php
+++ b/survey/sync.php
@@ -1,0 +1,94 @@
+<?php
+opcache_reset();
+$path = '../inc/lsapp.php';
+require($path); 
+require('functions.php');
+
+$data_path = '../data/surveys/';
+$logs_file = $data_path . 'logs.txt';
+
+$sync_logs = file_exists($logs_file) ? file($logs_file, FILE_IGNORE_NEW_LINES) : [];
+$sync_array = [];
+foreach ($sync_logs as $log) {
+    $breakpoint = strpos($log, ' - ');
+    $timestamp = substr($log, 0, $breakpoint);
+    $entry = substr($log, $breakpoint);
+    $sync_array[] = [$timestamp, $entry];
+}
+// reverse sort by timestamp
+usort($sync_array, function ($a, $b) {
+    return $b[0] <=> $a[0];
+})
+
+?>
+
+
+<?php if(canACcess()): ?>
+
+<?php getHeader() ?>
+    <title>Survey Sync</title>
+    <script src="/lsapp/js/list.min.js"></script>
+
+<?php getScripts() ?>
+<body>
+<?php getNavigation() ?>
+
+<div class="container-fluid">
+<div class="row justify-content-md-center mb-3">
+    <div class="col-12">
+        <h1 class="mb-5 text-center">Survey Sync</h1>
+    </div>
+</div> <!-- /row -->
+
+<div class="container-lg">
+
+    <?php $flash_alerts = AlertManager::getAlertsAll(); ?>
+    <?php if (count($flash_alerts) > 0): ?>
+        <?php foreach ($flash_alerts as $falert): ?>
+            <div class="alert alert-<?= $falert['type'] ?>" role="alert">
+                <?= $falert['message'] ?><br>
+            </div>
+        <?php endforeach; ?>
+    <?php endif; ?>
+
+</div>
+
+<div class="container-lg justify-content-between bg-light-subtle rounded-top border-secondary-subtle border-start border-top border-end">
+    <div class="row">
+        <div class="d-flex p-2">
+            <div class="ms-3">
+                <h2>Recent Sync Logs</h2>
+            </div>   
+            <div class="ms-auto">
+                <a class="btn btn-primary" href="./evaluation-sync.php" role="button">Run Sync</a>
+            </div>
+        </div>
+    </div> <!-- /row -->
+</div>
+
+<div class="container-lg p-3 border border-secondary-subtle bg-secondary-subtle rounded-bottom">
+    <div class="row">
+
+        <div class="col">
+    
+            <div class="text-bg-light rounded border border-dark-subtle m-1 p-3">
+                <?php foreach($sync_array as $log): ?>
+                    <span class="font-monospace"><?= $log[0] . $log[1] ?></span><br>
+                <?php endforeach; ?>
+            </div>
+        
+        </div>
+
+    </div>
+
+</div> <!-- /container -->
+
+
+</div> <!-- /container -->
+
+
+<?php endif ?> <!-- //canACcess() -->
+
+</body>
+<?php require('../templates/javascript.php') ?>
+<?php require('../templates/footer.php') ?>


### PR DESCRIPTION
The core of these updates were around updating the main sync to run quick enough to avoid timing out, which necessitated adding some new fields to keep track of when different pieces were last synchronized so we can build a priority list of 10 surveys to sync at a time.

Additional changes include:
 - Adding the new last sync values to the index list of surveys
 - Adding a sort to the survey list
 - Rudimentary logging to capture which surveys have been synced
 - A basic sync homepage where the full sync can be initiated, and displays the captured sync logs