### PR TITLE
add conversion from Windows-1252 to UTF-8 #187

### DIFF
--- a/course-feed/process.php
+++ b/course-feed/process.php
@@ -29,7 +29,8 @@ function processCsvFile($filename) {
     $csvData = [];
     $columnNames = fgetcsv($handle);
     while (($row = fgetcsv($handle)) !== false) {
-        $csvData[] = array_combine($columnNames, $row);
+        $rowUtfEncoded = mb_convert_encoding($row, 'UTF-8', 'Windows-1252');
+        $csvData[] = array_combine($columnNames, $rowUtfEncoded);
     }
     fclose($handle);
     return $csvData;


### PR DESCRIPTION
Should hopefully fix an issue that was resulting in the character "é" getting converted to � and subsequently removed as part of the sync process by converting to the expected UTF-8 encoding.